### PR TITLE
Add Next.js page for barcode scanning

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,86 @@
+import { useState, useRef } from 'react';
+import dynamic from 'next/dynamic';
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+
+const Quagga = dynamic(() => import('quagga'), { ssr: false });
+
+function getCodeType(code: string) {
+  if (/^\d{12}$/.test(code)) return 'UPC';
+  if (/^\d{13}$/.test(code)) {
+    if (code.startsWith('978') || code.startsWith('979')) return 'ISBN-13';
+    return 'EAN-13';
+  }
+  if (/^\d{9}[\dXx]$/.test(code)) return 'ISBN-10';
+  return 'Unknown';
+}
+
+export default function Page() {
+  const [code, setCode] = useState('');
+  const [result, setResult] = useState<any>(null);
+  const [scanning, setScanning] = useState(false);
+  const scannerRef = useRef<HTMLDivElement>(null);
+
+  async function search(code: string) {
+    const type = getCodeType(code);
+    try {
+      const resp = await fetch(`/api/search/${code}`);
+      const data = await resp.json();
+      setResult({ type, data });
+    } catch (e: any) {
+      setResult({ error: e.message });
+    }
+  }
+
+  function startScanner() {
+    if (!scannerRef.current) return;
+    setScanning(true);
+    Quagga.init({
+      inputStream: {
+        name: 'Live',
+        type: 'LiveStream',
+        target: scannerRef.current
+      },
+      decoder: {
+        readers: ['ean_reader', 'ean_13_reader', 'upc_reader', 'upc_e_reader']
+      }
+    }, (err: any) => {
+      if (err) { console.error(err); return; }
+      Quagga.start();
+    });
+
+    Quagga.onDetected(data => {
+      const c = data.codeResult.code;
+      setCode(c);
+      stopScanner();
+      search(c);
+    });
+  }
+
+  function stopScanner() {
+    Quagga.stop();
+    setScanning(false);
+    if (scannerRef.current) scannerRef.current.innerHTML = '';
+  }
+
+  return (
+    <div className="p-4 space-y-4">
+      <h2 className="text-xl font-bold">Buscar producto</h2>
+      <Input
+        placeholder="Ingresa o escanea un código"
+        value={code}
+        onChange={e => setCode(e.target.value)}
+        onBlur={() => code && search(code)}
+      />
+      <Button onClick={scanning ? stopScanner : startScanner}>
+        {scanning ? 'Detener' : 'Escanear con cámara'}
+      </Button>
+      <div ref={scannerRef} className="w-full max-w-xs mx-auto" />
+      {result && (
+        <pre className="whitespace-pre-wrap break-all text-sm">
+          {JSON.stringify(result, null, 2)}
+        </pre>
+      )}
+    </div>
+  );
+}

--- a/package.json
+++ b/package.json
@@ -14,7 +14,11 @@
     "dotenv": "^16.4.5",
     "express": "^4.19.2",
     "mongoose": "^8.3.1",
-    "mongoose-auto-increment": "^5.0.1"
+    "mongoose-auto-increment": "^5.0.1",
+    "next": "^14.1.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "quagga": "^0.12.1"
   },
   "devDependencies": {
     "nodemon": "^3.1.0"

--- a/public/main.css
+++ b/public/main.css
@@ -32,3 +32,17 @@ input[type=submit]{
 .button a{
     color: #1a72cb;
 }
+
+/* estilos sencillos para pagina de escaneo */
+#code-input, button{
+    margin-top: 5px;
+}
+
+#scanner-container video{
+    width: 100%;
+    height: auto;
+}
+
+@media (max-width: 500px){
+    form{width:100%;}
+}

--- a/public/scan.html
+++ b/public/scan.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Escanear Código</title>
+  <link rel="stylesheet" href="main.css">
+  <style>
+    #scanner-container { display:none; width:100%; max-width:400px; margin:0 auto; }
+    #result { padding:10px; }
+    button { margin-top:10px; }
+  </style>
+</head>
+<body>
+  <h2>Buscar producto</h2>
+  <div class="section">
+    <input type="text" id="code-input" placeholder="Ingresa o escanea un código"/>
+    <button id="scan-button">Escanear con cámara</button>
+  </div>
+  <div id="scanner-container"></div>
+  <div id="result"></div>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/quagga/0.12.1/quagga.min.js"></script>
+  <script src="scan.js"></script>
+</body>
+</html>

--- a/public/scan.js
+++ b/public/scan.js
@@ -1,0 +1,57 @@
+function getCodeType(code){
+  if(/^\d{12}$/.test(code)) return 'UPC';
+  if(/^\d{13}$/.test(code)){
+    if(code.startsWith('978') || code.startsWith('979')) return 'ISBN-13';
+    return 'EAN-13';
+  }
+  if(/^\d{9}[\dXx]$/.test(code)) return 'ISBN-10';
+  return 'Unknown';
+}
+
+async function search(code){
+  const type = getCodeType(code);
+  const resultEl = document.getElementById('result');
+  try{
+    const resp = await fetch(`/api/search/${code}`);
+    const data = await resp.json();
+    resultEl.textContent = JSON.stringify({type, data}, null, 2);
+  }catch(e){
+    resultEl.textContent = 'Error al buscar el código';
+  }
+}
+
+const input = document.getElementById('code-input');
+input.addEventListener('change', () => {
+  const code = input.value.trim();
+  if(code) search(code);
+});
+
+document.getElementById('scan-button').addEventListener('click', () => {
+  const container = document.getElementById('scanner-container');
+  container.style.display = 'block';
+  Quagga.init({
+    inputStream: {
+      name: 'Live',
+      type: 'LiveStream',
+      target: container
+    },
+    decoder: {
+      readers: ['ean_reader','ean_13_reader','upc_reader','upc_e_reader']
+    }
+  }, (err) => {
+    if(err){
+      console.error(err);
+      return;
+    }
+    Quagga.start();
+  });
+
+  Quagga.onDetected(data => {
+    const code = data.codeResult.code;
+    input.value = code;
+    Quagga.stop();
+    container.innerHTML = '';
+    container.style.display = 'none';
+    search(code);
+  });
+});

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,8 @@ const express = require("express"); // llamo a express
 const mongoose = require("mongoose");
 require("dotenv").config(); //variable de ambiente
 const personasRoutes = require("./routes/personas");
+const codesRoutes = require("./routes/codes");
+const path = require('path');
 
 
 
@@ -14,6 +16,8 @@ const port = process.env.PORT || 8080; // conexion de puerto
 
 app.use(express.json());
 app.use('/api', personasRoutes);
+app.use('/api', codesRoutes);
+app.use(express.static(path.join(__dirname, '..', 'public')));
 
 
 //routes

--- a/src/routes/codes.js
+++ b/src/routes/codes.js
@@ -1,0 +1,32 @@
+const express = require('express');
+const router = express.Router();
+
+function getCodeType(code) {
+  if (/^\d{12}$/.test(code)) return 'UPC';
+  if (/^\d{13}$/.test(code)) {
+    if (code.startsWith('978') || code.startsWith('979')) return 'ISBN-13';
+    return 'EAN-13';
+  }
+  if (/^\d{9}[\dXx]$/.test(code)) return 'ISBN-10';
+  return 'Unknown';
+}
+
+router.get('/search/:code', async (req, res) => {
+  const { code } = req.params;
+  const type = getCodeType(code);
+  try {
+    let data = null;
+    if (type.startsWith('ISBN')) {
+      const resp = await fetch(`https://openlibrary.org/api/books?bibkeys=ISBN:${code}&format=json&jscmd=data`);
+      data = await resp.json();
+    } else if (type !== 'Unknown') {
+      const resp = await fetch(`https://world.openfoodfacts.org/api/v0/product/${code}.json`);
+      data = await resp.json();
+    }
+    res.json({ type, data });
+  } catch (err) {
+    res.status(500).json({ message: err.message });
+  }
+});
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- introduce `app/page.tsx` with Quagga-based scanner and Shadcn UI
- add `next`, `react`, `react-dom`, and `quagga` dependencies

## Testing
- `npm test` *(fails: Missing script)*
- `npm start` *(fails: nodemon permission denied)*
- `node src/index.js` *(fails to connect to MongoDB: ENOTFOUND)*


------
https://chatgpt.com/codex/tasks/task_e_686be570b62c832bb1c8b2960235ee7f